### PR TITLE
Add Aim: Open-source AI metadata tracker.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ There are many kinds of AutoML, including:
 - [AUTOPROMPT: Eliciting Knowledge from Language Models with Automatically Generated Prompts](https://arxiv.org/pdf/2010.15980.pdf) (Shin et al. 2020)
 
 ## Tools and projects
+- [Aim](https://github.com/aimhubio/aim): An easy-to-use & supercharged open-source AI metadata tracker
 - [Falcon](https://github.com/OKUA1/falcon): A Lightweight AutoML Library
 - [MindWare](https://github.com/PKU-DAIR/mindware): Efficient Open-source AutoML System
 - [AutoDL](https://github.com/DeepWisdom/AutoDL): automated deep learning


### PR DESCRIPTION
It would be great to have [Aim](https://github.com/aimhubio/aim) in the list.

Aim is an open-source, self-hosted AI Metadata tracking tool designed to handle 100,000s of tracked metadata sequences.

Aim provides a performant and beautiful UI for exploring and comparing metadata such as training runs or agents executions. Additionally, its SDK enables programmatic access to tracked metadata — perfect for automations and Jupyter Notebook analysis.

🖇 https://aimstack.io/